### PR TITLE
Rename channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Lawo S, Hasegan M, Gupta GD, Pelletier L.
 ### Description
 
 The centrosome is the main microtubule organization centre of animal cells. It is composed of a centriole pair surrounded by pericentriolar material (PCM). Traditionally described as amorphous, the architecture of the PCM is not known, although its intricate mode of assembly alludes to the presence of a functional, hierarchical structure. Here we used subdiffraction imaging to reveal organizational features of the PCM. Interphase PCM components adopt a concentric toroidal distribution of discrete diameter around centrioles. Positional mapping of multiple non-overlapping epitopes revealed that pericentrin (PCNT) is an elongated molecule extending away from the centriole. We find that PCM components occupy separable spatial domains within mitotic PCM that are maintained in the absence of microtubule nucleation complexes and further implicate PCNT and CDK5RAP2 in the organization and assembly of PCM. Globally, this work highlights the role of higher-order PCM organization in the regulation of centrosome assembly and function.
+
+## Steps post Import
+
+After importing the data and generating the map annotation, run [rename_channels.py](scripts/rename_channels.py) to set the channels' name.
+ 

--- a/scripts/rename_channels.py
+++ b/scripts/rename_channels.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# This script loads all the images in the study.
+# For each image, the map annotation is loaded and the channel name
+# is set.
+
+import sys
+import argparse
+import getpass
+
+import omero
+from omero.gateway import BlitzGateway
+
+NAMESPACE = omero.constants.namespaces.NSBULKANNOTATIONS
+KEY = "Channels"
+
+
+def change_name(conn, image):
+    for ann in image.listAnnotations():
+        if ann.OMERO_TYPE == omero.model.MapAnnotationI \
+           and ann.getNs() == NAMESPACE:
+            channels = dict(ann.getValue()).get(KEY)
+            if len(channels) > 0:
+                s = channels.replace(" ", "")
+                keys = dict(item.split(":") for item in s.split(";"))
+                print(keys)
+                name_dict = {}
+                index = 1
+                for channel in image.getChannels():
+                    value = channel.getName()
+                    lc = channel.getLogicalChannel()
+                    ew = lc.emissionWave
+                    if ew is not None:
+                        key = str(int(ew.getValue()))
+                        if key in keys:
+                            value = keys[key]
+
+                    name_dict[index] = value
+                    index += 1
+                conn.setChannelNames("Image", [image.getId()], name_dict,
+                                     channelCount=None)
+
+
+def load_images(conn, id):
+    datasets = conn.getObjects('Dataset', opts={'project': id})
+    for dataset in datasets:
+        for image in dataset.listChildren():
+            print("image %s" % image.getId())
+            change_name(conn, image)
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('id', help="The id of the project.")
+    parser.add_argument('--username', default="demo")
+    parser.add_argument('--server', default="localhost")
+    parser.add_argument('--port', default=4064)
+    args = parser.parse_args(args)
+    password = getpass.getpass()
+    # Create a connection
+    try:
+        conn = BlitzGateway(args.username, password, host=args.server,
+                            port=args.port)
+        conn.connect()
+        load_images(conn, args.id)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/rename_channels.py
+++ b/scripts/rename_channels.py
@@ -23,7 +23,6 @@ def change_name(conn, image):
             if len(channels) > 0:
                 s = channels.replace(" ", "")
                 keys = dict(item.split(":") for item in s.split(";"))
-                print(keys)
                 name_dict = {}
                 index = 1
                 for channel in image.getChannels():


### PR DESCRIPTION
set the name of the channels from map annotation value
The channel name is not set and it is available in the map annotation.

This was an issue that we encounter when analysing the data but also others when doing analysis across multiple studies since people use the channel's name as a way to select the channel to analyse

Tested the script on pilot-idr0091

cc @sbesson @joshmoore @francesw 